### PR TITLE
Fix JSON tags for Constraint

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Constraint struct {
-	Round    *int     `json:"omitempty"`
-	Max, Min *float64 `json:"omitempty"`
+	Round    *int     `json:",omitempty"`
+	Max, Min *float64 `json:",omitempty"`
 }
 
 var Config = struct {


### PR DESCRIPTION
`omitempty` is interpreted as the JSON key if not preceded by a comma